### PR TITLE
feat: request and response decorators

### DIFF
--- a/lib/decorators/parameter.decorator.spec.ts
+++ b/lib/decorators/parameter.decorator.spec.ts
@@ -1,7 +1,8 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-empty-function */
 import 'reflect-metadata';
-import { Body, PARAMETER_TOKEN, Header, Query } from './parameter.decorators';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { Body, PARAMETER_TOKEN, Req, Request, Res, Response, Header, Query } from './parameter.decorators';
 
 describe('Parameter decorators', () => {
   it('Body should be set.', () => {
@@ -48,6 +49,44 @@ describe('Parameter decorators', () => {
         { index: 0, location: 'query', name: 'firstName' },
         { index: 1, location: 'query', name: 'lastName' },
         { index: 2, location: 'query', name: 'city' }
+      ])
+    );
+  });
+
+  it('Req should be set.', () => {
+    class Test {
+      public index(@Req() req: NextApiRequest) {}
+    }
+
+    const meta = Reflect.getMetadata(PARAMETER_TOKEN, Test, 'index');
+    expect(Array.isArray(meta)).toBe(true);
+    expect(meta).toHaveLength(1);
+    expect(meta).toMatchObject(expect.arrayContaining([{ index: 0, location: 'request' }]));
+  });
+
+  it('Res should be set.', () => {
+    class Test {
+      public index(@Res() res: NextApiResponse) {}
+    }
+
+    const meta = Reflect.getMetadata(PARAMETER_TOKEN, Test, 'index');
+    expect(Array.isArray(meta)).toBe(true);
+    expect(meta).toHaveLength(1);
+    expect(meta).toMatchObject(expect.arrayContaining([{ index: 0, location: 'response' }]));
+  });
+
+  it('Request and Response should be set.', () => {
+    class Test {
+      public index(@Request() req: NextApiRequest, @Response() res: NextApiResponse) {}
+    }
+
+    const meta = Reflect.getMetadata(PARAMETER_TOKEN, Test, 'index');
+    expect(Array.isArray(meta)).toBe(true);
+    expect(meta).toHaveLength(2);
+    expect(meta).toMatchObject(
+      expect.arrayContaining([
+        { index: 0, location: 'request' },
+        { index: 1, location: 'response' }
       ])
     );
   });

--- a/lib/decorators/parameter.decorators.ts
+++ b/lib/decorators/parameter.decorators.ts
@@ -2,7 +2,7 @@ import type { ParameterPipe } from '../pipes/ParameterPipe';
 
 export interface MetaParameter {
   index: number;
-  location: 'query' | 'body' | 'header' | 'method';
+  location: 'query' | 'body' | 'header' | 'method' | 'request' | 'response';
   name?: string;
   pipes?: ParameterPipe<any>[];
 }
@@ -40,4 +40,24 @@ export function Body(): ParameterDecorator {
  */
 export function Header(name: string): ParameterDecorator {
   return addParameter('header', name);
+}
+
+/** Returns the `req` object. */
+export function Req(): ParameterDecorator {
+  return addParameter('request');
+}
+
+/** Returns the `req` object. */
+export function Request(): ParameterDecorator {
+  return Req();
+}
+
+/** Returns the `res` object. */
+export function Res(): ParameterDecorator {
+  return addParameter('response');
+}
+
+/** Returns the `res` object. */
+export function Response(): ParameterDecorator {
+  return Res();
 }

--- a/lib/e2e.test.ts
+++ b/lib/e2e.test.ts
@@ -1,8 +1,9 @@
 import 'reflect-metadata';
 import express from 'express';
+import type { NextApiRequest, NextApiResponse } from 'next';
 import request from 'supertest';
 import { createHandler } from './createHandler';
-import { Body, Delete, Get, Header, HttpCode, Post, Put, Query, SetHeader } from './decorators';
+import { Body, Delete, Get, Header, HttpCode, Post, Put, Query, Req, Response, SetHeader } from './decorators';
 import { ParseBooleanPipe } from './pipes/parseBoolean.pipe';
 import { ParseNumberPipe } from './pipes/parseNumber.pipe';
 
@@ -36,9 +37,16 @@ class TestHandler {
 
   @Delete()
   @SetHeader('X-Method', 'delete')
-  public delete(@Header('Content-Type') contentType: string, @Query('id') id: string, @Body() body: any) {
-    return { contentType, id, receivedBody: body, test: this.testField };
+  public delete(@Req() req: NextApiRequest, @Response() res: NextApiResponse) {
+    const { headers, query, body } = req;
+    const { 'content-type': contentType } = headers;
+    const { id } = query;
+
+    return res.status(200).json({ contentType, id, receivedBody: body, test: this.testField });
   }
+  // public delete(@Header('Content-Type') contentType: string, @Query('id') id: string, @Body() body: any) {
+  //   return { contentType, id, receivedBody: body, test: this.testField };
+  // }
 }
 
 describe('E2E', () => {

--- a/lib/e2e.test.ts
+++ b/lib/e2e.test.ts
@@ -75,9 +75,6 @@ class TestHandler {
 
     return res.status(200).json({ contentType, id, receivedBody: body, test: this.testField });
   }
-  // public delete(@Header('Content-Type') contentType: string, @Query('id') id: string, @Body() body: any) {
-  //   return { contentType, id, receivedBody: body, test: this.testField };
-  // }
 }
 
 describe('E2E', () => {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,6 +1,21 @@
 import 'reflect-metadata';
 
 export * from './createHandler';
-export { Body, Delete, Get, Header, HttpCode, HttpVerb, Post, Put, Query, SetHeader } from './decorators';
+export {
+  Body,
+  Delete,
+  Get,
+  Header,
+  HttpCode,
+  HttpVerb,
+  Post,
+  Put,
+  Query,
+  SetHeader,
+  Req,
+  Request,
+  Res,
+  Response
+} from './decorators';
 export * from './exceptions';
 export * from './pipes';


### PR DESCRIPTION
Added `@Req` and `@Res` decorators along with aliases `@Request` and `@Response` for manual usage.

Closes #13 