### PR TITLE
chore: skip validation when class-validator/transformer is not installed

### DIFF
--- a/lib/internals/classValidator.ts
+++ b/lib/internals/classValidator.ts
@@ -1,13 +1,23 @@
-import { ClassConstructor, plainToClass } from 'class-transformer';
-import { validate } from 'class-validator';
+import type { ClassConstructor } from 'class-transformer';
 import { BadRequestException } from '../exceptions';
 import { flattenValidationErrors } from './getClassValidatorError';
+import { loadPackage } from './loadPackage';
 
 export async function validateObject(cls: ClassConstructor<any>, value: Record<string, string>): Promise<any> {
-  const bodyValue = plainToClass(cls, value, {
+  const classValidator = loadPackage('class-validator');
+  if (!classValidator) {
+    return value;
+  }
+
+  const classTransformer = loadPackage('class-transformer');
+  if (!classTransformer) {
+    return value;
+  }
+
+  const bodyValue = classTransformer.plainToClass(cls, value, {
     enableImplicitConversion: true
   });
-  const validationErrors = await validate(bodyValue, {
+  const validationErrors = await classValidator.validate(bodyValue, {
     enableDebugMessages: process.env.NODE_ENV === 'development'
   });
 

--- a/lib/internals/loadPackage.ts
+++ b/lib/internals/loadPackage.ts
@@ -1,0 +1,7 @@
+export function loadPackage(name: string): any {
+  try {
+    return require(name);
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
When not using `class-validator` and `class-transformer`, those packages should not be loaded.