### PR TITLE
Parser options

### DIFF
--- a/lib/e2e.test.ts
+++ b/lib/e2e.test.ts
@@ -47,7 +47,7 @@ class TestHandler {
   public read(
     @Header('Content-Type') contentType: string,
     @Query('id') id: string,
-    @Query('step', ParseNumberPipe) step: number,
+    @Query('step', ParseNumberPipe({ nullable: false })) step: number,
     @Query('redirect', ParseBooleanPipe) redirect: boolean
   ) {
     return { contentType, id, step, redirect, test: this.testField };
@@ -73,7 +73,7 @@ class TestHandler {
     const { 'content-type': contentType } = headers;
     const { id } = query;
 
-    return res.status(200).json({ contentType, id, receivedBody: body, test: this.testField });
+    res.status(200).json({ contentType, id, receivedBody: body, test: this.testField });
   }
 }
 
@@ -104,6 +104,19 @@ describe('E2E', () => {
             id: 'my-id',
             step: 1,
             redirect: true
+          }
+        })
+      ));
+
+  it('read', () =>
+    request(server)
+      .get('/?id=my-id&redirect=true')
+      .set('Content-Type', 'application/json')
+      .expect(400)
+      .then(res =>
+        expect(res).toMatchObject({
+          body: {
+            message: 'step is a required parameter.'
           }
         })
       ));

--- a/lib/pipes/ParameterPipe.ts
+++ b/lib/pipes/ParameterPipe.ts
@@ -1,1 +1,5 @@
-export type ParameterPipe<T> = (value: any) => T;
+export interface PipeOptions {
+  nullable?: boolean;
+}
+
+export type ParameterPipe<T> = (value: any, name?: string) => T;

--- a/lib/pipes/parseBoolean.pipe.spec.ts
+++ b/lib/pipes/parseBoolean.pipe.spec.ts
@@ -6,6 +6,9 @@ describe('ParseBooleanPipe', () => {
   it('Should parse the given string as boolean (false)', () =>
     expect(ParseBooleanPipe()('false')).toStrictEqual(false));
 
+  it('Should throw required error the given value is empty', () =>
+    expect(() => ParseBooleanPipe({ nullable: false })('')).toThrow());
+
   it('Should throw when the given string is not a boolean string', () =>
-    expect(() => ParseBooleanPipe()('teste')).toThrow());
+    expect(() => ParseBooleanPipe()('test')).toThrow());
 });

--- a/lib/pipes/parseBoolean.pipe.spec.ts
+++ b/lib/pipes/parseBoolean.pipe.spec.ts
@@ -1,10 +1,11 @@
 import { ParseBooleanPipe } from './parseBoolean.pipe';
 
 describe('ParseBooleanPipe', () => {
-  it('Should parse the given string as boolean (true)', () => expect(ParseBooleanPipe('true')).toStrictEqual(true));
+  it('Should parse the given string as boolean (true)', () => expect(ParseBooleanPipe()('true')).toStrictEqual(true));
 
-  it('Should parse the given string as boolean (false)', () => expect(ParseBooleanPipe('false')).toStrictEqual(false));
+  it('Should parse the given string as boolean (false)', () =>
+    expect(ParseBooleanPipe()('false')).toStrictEqual(false));
 
   it('Should throw when the given string is not a boolean string', () =>
-    expect(() => ParseBooleanPipe('test')).toThrow());
+    expect(() => ParseBooleanPipe()('teste')).toThrow());
 });

--- a/lib/pipes/parseBoolean.pipe.ts
+++ b/lib/pipes/parseBoolean.pipe.ts
@@ -1,11 +1,10 @@
 import { BadRequestException } from '../exceptions';
 import type { ParameterPipe, PipeOptions } from './ParameterPipe';
+import { validatePipeOptions } from './validatePipeOptions';
 
 export function ParseBooleanPipe(options?: PipeOptions): ParameterPipe<boolean> {
   return (value: any, name?: string) => {
-    if (!options?.nullable && value == null) {
-      throw new BadRequestException(name ? `${name} is a required parameter.` : 'Missing a required parameter.');
-    }
+    validatePipeOptions(value, name, options);
 
     if (value === true || value === 'true') {
       return true;
@@ -15,6 +14,6 @@ export function ParseBooleanPipe(options?: PipeOptions): ParameterPipe<boolean> 
       return false;
     }
 
-    throw new BadRequestException('Validation failed (boolean string is expected)');
+    throw new BadRequestException(`Validation failed${name ? ` for ${name}` : ''} (boolean string is expected)`);
   };
 }

--- a/lib/pipes/parseBoolean.pipe.ts
+++ b/lib/pipes/parseBoolean.pipe.ts
@@ -2,9 +2,9 @@ import { BadRequestException } from '../exceptions';
 import type { ParameterPipe, PipeOptions } from './ParameterPipe';
 
 export function ParseBooleanPipe(options?: PipeOptions): ParameterPipe<boolean> {
-  return (value: any) => {
+  return (value: any, name?: string) => {
     if (!options?.nullable && value == null) {
-      throw new BadRequestException('Value needed.');
+      throw new BadRequestException(name ? `${name} is a required parameter.` : 'Missing a required parameter.');
     }
 
     if (value === true || value === 'true') {

--- a/lib/pipes/parseBoolean.pipe.ts
+++ b/lib/pipes/parseBoolean.pipe.ts
@@ -1,13 +1,20 @@
 import { BadRequestException } from '../exceptions';
+import type { ParameterPipe, PipeOptions } from './ParameterPipe';
 
-export function ParseBooleanPipe(value: any): boolean {
-  if (value === true || value === 'true') {
-    return true;
-  }
+export function ParseBooleanPipe(options?: PipeOptions): ParameterPipe<boolean> {
+  return (value: any) => {
+    if (!options?.nullable && value == null) {
+      throw new BadRequestException('Value needed.');
+    }
 
-  if (value === false || value === 'false') {
-    return false;
-  }
+    if (value === true || value === 'true') {
+      return true;
+    }
 
-  throw new BadRequestException('Validation failed (boolean string is expected)');
+    if (value === false || value === 'false') {
+      return false;
+    }
+
+    throw new BadRequestException('Validation failed (boolean string is expected)');
+  };
 }

--- a/lib/pipes/parseNumber.pipe.spec.ts
+++ b/lib/pipes/parseNumber.pipe.spec.ts
@@ -1,11 +1,11 @@
 import { ParseNumberPipe } from './parseNumber.pipe';
 
 describe('ParseNumberPipe', () => {
-  it('Should parse the given string as number', () => expect(ParseNumberPipe('10')).toStrictEqual(10));
+  it('Should parse the given string as number', () => expect(ParseNumberPipe()('10')).toStrictEqual(10));
 
   it('Should parse the given string as number with decimal points', () =>
-    expect(ParseNumberPipe('07.99')).toStrictEqual(7.99));
+    expect(ParseNumberPipe()('07.99')).toStrictEqual(7.99));
 
   it('Should throw when the given string is not a numeric string', () =>
-    expect(() => ParseNumberPipe('test')).toThrow());
+    expect(() => ParseNumberPipe()('test')).toThrow());
 });

--- a/lib/pipes/parseNumber.pipe.spec.ts
+++ b/lib/pipes/parseNumber.pipe.spec.ts
@@ -6,6 +6,9 @@ describe('ParseNumberPipe', () => {
   it('Should parse the given string as number with decimal points', () =>
     expect(ParseNumberPipe()('07.99')).toStrictEqual(7.99));
 
+  it('Should throw required error the given value is empty', () =>
+    expect(() => ParseNumberPipe({ nullable: false })('')).toThrow());
+
   it('Should throw when the given string is not a numeric string', () =>
     expect(() => ParseNumberPipe()('test')).toThrow());
 });

--- a/lib/pipes/parseNumber.pipe.ts
+++ b/lib/pipes/parseNumber.pipe.ts
@@ -1,16 +1,16 @@
 import { BadRequestException } from '../exceptions';
 import type { ParameterPipe, PipeOptions } from './ParameterPipe';
+import { validatePipeOptions } from './validatePipeOptions';
 
 export function ParseNumberPipe(options?: PipeOptions): ParameterPipe<number> {
   return (value: any, name?: string) => {
-    if (!options?.nullable && value == null) {
-      throw new BadRequestException(name ? `${name} is a required parameter.` : 'Missing a required parameter');
-    }
+    validatePipeOptions(value, name, options);
 
     const isNumeric = ['string', 'number'].includes(typeof value) && !isNaN(parseFloat(value)) && isFinite(value);
     if (!isNumeric) {
-      throw new BadRequestException('Validation failed (numeric string is expected)');
+      throw new BadRequestException(`Validation failed${name ? ` for ${name}` : ''} (numeric string is expected)`);
     }
+
     return parseFloat(value);
   };
 }

--- a/lib/pipes/parseNumber.pipe.ts
+++ b/lib/pipes/parseNumber.pipe.ts
@@ -1,9 +1,16 @@
 import { BadRequestException } from '../exceptions';
+import type { ParameterPipe, PipeOptions } from './ParameterPipe';
 
-export function ParseNumberPipe(value: any): number {
-  const isNumeric = ['string', 'number'].includes(typeof value) && !isNaN(parseFloat(value)) && isFinite(value);
-  if (!isNumeric) {
-    throw new BadRequestException('Validation failed (numeric string is expected)');
-  }
-  return parseFloat(value);
+export function ParseNumberPipe(options?: PipeOptions): ParameterPipe<number> {
+  return (value: any, name?: string) => {
+    if (!options?.nullable && value == null) {
+      throw new BadRequestException(name ? `${name} is a required parameter.` : 'Missing a required parameter');
+    }
+
+    const isNumeric = ['string', 'number'].includes(typeof value) && !isNaN(parseFloat(value)) && isFinite(value);
+    if (!isNumeric) {
+      throw new BadRequestException('Validation failed (numeric string is expected)');
+    }
+    return parseFloat(value);
+  };
 }

--- a/lib/pipes/validatePipeOptions.ts
+++ b/lib/pipes/validatePipeOptions.ts
@@ -1,0 +1,8 @@
+import { BadRequestException } from '../exceptions';
+import type { PipeOptions } from './ParameterPipe';
+
+export function validatePipeOptions(value: any, name?: string, options?: PipeOptions) {
+  if (!options?.nullable && (value == null || value.toString().trim().length === 0)) {
+    throw new BadRequestException(name ? `${name} is a required parameter.` : 'Missing a required parameter.');
+  }
+}


### PR DESCRIPTION
* Allow parsers to have options.
* Pass field name into pipes and use it in the error message.
* Removed `console.error` from the handler.