### PR TITLE
[refactor] pipes

### DIFF
--- a/lib/decorators/parameter.decorator.spec.ts
+++ b/lib/decorators/parameter.decorator.spec.ts
@@ -13,7 +13,7 @@ describe('Parameter decorators', () => {
     const meta = Reflect.getMetadata(PARAMETER_TOKEN, Test, 'index');
     expect(Array.isArray(meta)).toBe(true);
     expect(meta).toHaveLength(1);
-    expect(meta).toMatchObject(expect.arrayContaining([{ index: 0, location: 'body' }]));
+    expect(meta).toMatchObject(expect.arrayContaining([expect.objectContaining({ index: 0, location: 'body' })]));
   });
 
   it('Header should be set.', () => {
@@ -26,13 +26,26 @@ describe('Parameter decorators', () => {
     expect(meta).toHaveLength(2);
     expect(meta).toMatchObject(
       expect.arrayContaining([
-        { index: 0, location: 'header', name: 'Content-Type' },
-        { index: 1, location: 'header', name: 'Referer' }
+        expect.objectContaining({ index: 0, location: 'header', name: 'Content-Type' }),
+        expect.objectContaining({ index: 1, location: 'header', name: 'Referer' })
       ])
     );
   });
 
-  it('Header should be set.', () => {
+  it('Query should be set for the whole query string.', () => {
+    class Test {
+      public index(@Query() query: any) {}
+    }
+
+    const meta = Reflect.getMetadata(PARAMETER_TOKEN, Test, 'index');
+    expect(Array.isArray(meta)).toBe(true);
+    expect(meta).toHaveLength(1);
+    expect(meta).toMatchObject(
+      expect.arrayContaining([expect.objectContaining({ index: 0, location: 'query', name: undefined })])
+    );
+  });
+
+  it('Query parameters should be set.', () => {
     class Test {
       public index(
         @Query('firstName') firstName: string,
@@ -46,9 +59,9 @@ describe('Parameter decorators', () => {
     expect(meta).toHaveLength(3);
     expect(meta).toMatchObject(
       expect.arrayContaining([
-        { index: 0, location: 'query', name: 'firstName' },
-        { index: 1, location: 'query', name: 'lastName' },
-        { index: 2, location: 'query', name: 'city' }
+        expect.objectContaining({ index: 0, location: 'query', name: 'firstName' }),
+        expect.objectContaining({ index: 1, location: 'query', name: 'lastName' }),
+        expect.objectContaining({ index: 2, location: 'query', name: 'city' })
       ])
     );
   });
@@ -61,7 +74,7 @@ describe('Parameter decorators', () => {
     const meta = Reflect.getMetadata(PARAMETER_TOKEN, Test, 'index');
     expect(Array.isArray(meta)).toBe(true);
     expect(meta).toHaveLength(1);
-    expect(meta).toMatchObject(expect.arrayContaining([{ index: 0, location: 'request' }]));
+    expect(meta).toMatchObject(expect.arrayContaining([expect.objectContaining({ index: 0, location: 'request' })]));
   });
 
   it('Res should be set.', () => {
@@ -72,7 +85,7 @@ describe('Parameter decorators', () => {
     const meta = Reflect.getMetadata(PARAMETER_TOKEN, Test, 'index');
     expect(Array.isArray(meta)).toBe(true);
     expect(meta).toHaveLength(1);
-    expect(meta).toMatchObject(expect.arrayContaining([{ index: 0, location: 'response' }]));
+    expect(meta).toMatchObject(expect.arrayContaining([expect.objectContaining({ index: 0, location: 'response' })]));
   });
 
   it('Request and Response should be set.', () => {
@@ -85,8 +98,8 @@ describe('Parameter decorators', () => {
     expect(meta).toHaveLength(2);
     expect(meta).toMatchObject(
       expect.arrayContaining([
-        { index: 0, location: 'request' },
-        { index: 1, location: 'response' }
+        expect.objectContaining({ index: 0, location: 'request' }),
+        expect.objectContaining({ index: 1, location: 'response' })
       ])
     );
   });

--- a/lib/decorators/parameter.decorators.ts
+++ b/lib/decorators/parameter.decorators.ts
@@ -19,18 +19,33 @@ function addParameter(location: MetaParameter['location'], name?: MetaParameter[
   };
 }
 
+/** Returns the query string. */
+export function Query(): ParameterDecorator;
 /**
  * Returns a parameter from the query string.
  *
  * @param name Parameter name
  */
-export function Query(name: string, ...pipes: ParameterPipe<any>[]): ParameterDecorator {
-  return addParameter('query', name, pipes.length ? pipes : undefined);
+export function Query(name: string, ...pipes: ParameterPipe<any>[]): ParameterDecorator;
+/**
+ * Returns the query string with pipes applied.
+ *
+ * @param pipes Pipes to be applied.
+ */
+export function Query(...pipes: ParameterPipe<any>[]): ParameterDecorator;
+export function Query(nameOrPipes?: string | ParameterPipe<any>, ...pipes: ParameterPipe<any>[]): ParameterDecorator {
+  if (typeof nameOrPipes === 'string') {
+    return addParameter('query', nameOrPipes, pipes.length ? pipes : undefined);
+  } else if (typeof nameOrPipes === 'function') {
+    return addParameter('query', undefined, [nameOrPipes, ...pipes]);
+  } else {
+    return addParameter('query', undefined);
+  }
 }
 
 /** Returns the request body. */
-export function Body(): ParameterDecorator {
-  return addParameter('body');
+export function Body(...pipes: ParameterPipe<any>[]): ParameterDecorator {
+  return addParameter('body', undefined, pipes);
 }
 
 /**

--- a/lib/internals/classValidator.ts
+++ b/lib/internals/classValidator.ts
@@ -1,9 +1,14 @@
 import type { ClassConstructor } from 'class-transformer';
 import { BadRequestException } from '../exceptions';
+import type { ValidationPipeOptions } from '../pipes';
 import { flattenValidationErrors } from './getClassValidatorError';
 import { loadPackage } from './loadPackage';
 
-export async function validateObject(cls: ClassConstructor<any>, value: Record<string, string>): Promise<any> {
+export async function validateObject(
+  cls: ClassConstructor<any>,
+  value: Record<string, string>,
+  validatorOptions?: ValidationPipeOptions
+): Promise<any> {
   const classValidator = loadPackage('class-validator');
   if (!classValidator) {
     return value;
@@ -15,10 +20,12 @@ export async function validateObject(cls: ClassConstructor<any>, value: Record<s
   }
 
   const bodyValue = classTransformer.plainToClass(cls, value, {
-    enableImplicitConversion: true
+    enableImplicitConversion: true,
+    ...validatorOptions?.transformOptions
   });
   const validationErrors = await classValidator.validate(bodyValue, {
-    enableDebugMessages: process.env.NODE_ENV === 'development'
+    enableDebugMessages: process.env.NODE_ENV === 'development',
+    ...validatorOptions
   });
 
   if (validationErrors.length) {

--- a/lib/pipes/ParameterPipe.ts
+++ b/lib/pipes/ParameterPipe.ts
@@ -1,5 +1,10 @@
-export interface PipeOptions {
-  nullable?: boolean;
+export interface PipeMetadata<T = any> {
+  readonly metaType?: T;
+  readonly name?: string;
 }
 
-export type ParameterPipe<T> = (value: any, name?: string) => T;
+export interface PipeOptions {
+  readonly nullable?: boolean;
+}
+
+export type ParameterPipe<TOutput, TMeta = unknown> = (value: any, metadata?: PipeMetadata<TMeta>) => TOutput;

--- a/lib/pipes/index.ts
+++ b/lib/pipes/index.ts
@@ -1,2 +1,4 @@
 export * from './parseBoolean.pipe';
 export * from './parseNumber.pipe';
+export * from './validation.pipe';
+export * from './validateEnum.pipe';

--- a/lib/pipes/parseBoolean.pipe.ts
+++ b/lib/pipes/parseBoolean.pipe.ts
@@ -1,10 +1,10 @@
 import { BadRequestException } from '../exceptions';
-import type { ParameterPipe, PipeOptions } from './ParameterPipe';
+import type { ParameterPipe, PipeOptions, PipeMetadata } from './ParameterPipe';
 import { validatePipeOptions } from './validatePipeOptions';
 
 export function ParseBooleanPipe(options?: PipeOptions): ParameterPipe<boolean> {
-  return (value: any, name?: string) => {
-    validatePipeOptions(value, name, options);
+  return (value: any, metadata?: PipeMetadata) => {
+    validatePipeOptions(value, metadata?.name, options);
 
     if (value === true || value === 'true') {
       return true;
@@ -14,6 +14,8 @@ export function ParseBooleanPipe(options?: PipeOptions): ParameterPipe<boolean> 
       return false;
     }
 
-    throw new BadRequestException(`Validation failed${name ? ` for ${name}` : ''} (boolean string is expected)`);
+    throw new BadRequestException(
+      `Validation failed${metadata?.name ? ` for ${metadata.name}` : ''} (boolean string is expected)`
+    );
   };
 }

--- a/lib/pipes/parseNumber.pipe.ts
+++ b/lib/pipes/parseNumber.pipe.ts
@@ -1,14 +1,16 @@
 import { BadRequestException } from '../exceptions';
-import type { ParameterPipe, PipeOptions } from './ParameterPipe';
+import type { ParameterPipe, PipeOptions, PipeMetadata } from './ParameterPipe';
 import { validatePipeOptions } from './validatePipeOptions';
 
 export function ParseNumberPipe(options?: PipeOptions): ParameterPipe<number> {
-  return (value: any, name?: string) => {
-    validatePipeOptions(value, name, options);
+  return (value: any, metadata?: PipeMetadata) => {
+    validatePipeOptions(value, metadata?.name, options);
 
     const isNumeric = ['string', 'number'].includes(typeof value) && !isNaN(parseFloat(value)) && isFinite(value);
     if (!isNumeric) {
-      throw new BadRequestException(`Validation failed${name ? ` for ${name}` : ''} (numeric string is expected)`);
+      throw new BadRequestException(
+        `Validation failed${metadata?.name ? ` for ${metadata.name}` : ''} (numeric string is expected)`
+      );
     }
 
     return parseFloat(value);

--- a/lib/pipes/validateEnum.pipe.spec.ts
+++ b/lib/pipes/validateEnum.pipe.spec.ts
@@ -1,0 +1,27 @@
+import { ValidateEnumPipe } from './validateEnum.pipe';
+
+enum UserStatus {
+  ACTIVE = 'active',
+  INACTIVE = 'inactive',
+  BANNED = 'banned',
+  DELETED = 'deleted'
+}
+
+describe('ValidateEnumPipe', () => {
+  it('Should pass with a correct value', () =>
+    expect(ValidateEnumPipe({ type: UserStatus })('banned', { name: 'status' })).toStrictEqual(UserStatus.BANNED));
+
+  it('Should throw when the given value is an invalid enum value', () =>
+    expect(() => ValidateEnumPipe({ type: UserStatus })('test', { name: 'status' })).toThrow());
+
+  it('Should throw when pipe is non-nullable and the given value is undefined.', () =>
+    expect(() => ValidateEnumPipe({ type: UserStatus, nullable: false })(undefined, { name: 'status' })).toThrow());
+
+  it('Should pass when pipe is non-nullable and the given value is undefined.', () =>
+    expect(ValidateEnumPipe({ type: UserStatus, nullable: true })(undefined, { name: 'status' })).toStrictEqual(
+      undefined
+    ));
+
+  it('Should pass when the given value is invalid but there is no type', () =>
+    expect(ValidateEnumPipe()('unknown', { name: 'status' })).toStrictEqual('unknown'));
+});

--- a/lib/pipes/validateEnum.pipe.ts
+++ b/lib/pipes/validateEnum.pipe.ts
@@ -1,0 +1,28 @@
+import { BadRequestException } from '../exceptions';
+import type { ParameterPipe, PipeOptions, PipeMetadata } from './ParameterPipe';
+import { validatePipeOptions } from './validatePipeOptions';
+
+interface ValidateEnumPipeOptions<T extends Record<string, unknown>> extends PipeOptions {
+  type: T;
+}
+
+export function ValidateEnumPipe<T extends Record<string, unknown>>(
+  options?: ValidateEnumPipeOptions<T>
+): ParameterPipe<number> {
+  return (value: any, metadata?: PipeMetadata) => {
+    validatePipeOptions(value, metadata?.name, options);
+
+    if (value && options?.type) {
+      const values = Object.values(options.type);
+      if (!values.includes(value)) {
+        throw new BadRequestException(
+          `Validation failed${metadata?.name ? ` for ${metadata.name}` : ''} (expected one of the values: ${values.join(
+            ', '
+          )})`
+        );
+      }
+    }
+
+    return value;
+  };
+}

--- a/lib/pipes/validation.pipe.ts
+++ b/lib/pipes/validation.pipe.ts
@@ -1,0 +1,18 @@
+import type { ClassTransformOptions } from 'class-transformer';
+import type { ValidatorOptions } from 'class-validator';
+import { validateObject } from '../internals/classValidator';
+import type { ParameterPipe, PipeMetadata } from './ParameterPipe';
+
+export interface ValidationPipeOptions extends ValidatorOptions {
+  transformOptions?: ClassTransformOptions;
+}
+
+export function ValidationPipe(options?: ValidationPipeOptions): ParameterPipe<any> {
+  return (value: any, metadata?: PipeMetadata) => {
+    if (!metadata?.metaType) {
+      return value;
+    }
+
+    return validateObject(metadata?.metaType, value, options);
+  };
+}


### PR DESCRIPTION
* Instead of passing `name` to pipes as the second parameter, now we pass metadata which includes the name and the type.
* Body validation via `class-validator` was enabled by default, which means if you'd use a class without wanting to validate it, your app would throw since it'd look for `class-validator` package. Now you can use a class without `class-validator`, but if you want to use `class-validator` you have to add `ValidationPipe` to your `@Body` decorator.
* Added `ValidateEnum` Closes #19 
* Overloads for the `@Query` decorator so you can get the whole query string as an object, apply pipes to it.