### PR TITLE
fix: allow next 11 peerDep

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "peerDependencies": {
     "@babel/plugin-proposal-decorators": "^7.13.15",
     "babel-plugin-parameter-decorator": "^1.0.16",
-    "next": "^10.0.0"
+    "next": ">=10.0.0"
   },
   "devDependencies": {
     "@commitlint/cli": "12.1.4",


### PR DESCRIPTION
This PR allows users to install this package with next@10 or higher.

Fixes the error below: 

![image](https://user-images.githubusercontent.com/53900565/124083296-fc96a480-da4d-11eb-801e-d5242a141be9.png)
