### PR TITLE
fix: specify package names to load for webpack

### DIFF
--- a/lib/internals/loadPackage.spec.ts
+++ b/lib/internals/loadPackage.spec.ts
@@ -4,6 +4,8 @@ describe('loadPackage', () => {
   it('Should load a package correctly.', () => expect(loadPackage('class-validator')).not.toEqual(false));
 
   it('Should return false for a non existing package.', () =>
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
     expect(loadPackage('a-package-that-does-not-exist')).toEqual(false));
 
   it('Should not log warnings for a existing package.', () => {
@@ -19,6 +21,8 @@ describe('loadPackage', () => {
   it('Should log warnings for a non-existing package.', () => {
     const spy = jest.spyOn(console, 'warn').mockImplementation();
 
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
     loadPackage('a-package-that-does-not-exist', { context: 'test', docsUrl: 'https://example.com/' });
 
     expect(spy).toBeCalledTimes(2);

--- a/lib/internals/loadPackage.ts
+++ b/lib/internals/loadPackage.ts
@@ -3,9 +3,20 @@ interface LoadPackageWarning {
   docsUrl: string;
 }
 
-export function loadPackage(name: string, warning?: LoadPackageWarning): any {
+type LoadablePackages = 'path-to-regexp' | 'class-validator' | 'class-transformer';
+
+export function loadPackage(name: LoadablePackages, warning?: LoadPackageWarning): any {
   try {
-    return require(name);
+    switch (name) {
+      case 'path-to-regexp':
+        return require('path-to-regexp');
+      case 'class-transformer':
+        return require('class-transformer');
+      case 'class-validator':
+        return require('class-validator');
+      default:
+        throw new Error('Invalid package name.');
+    }
   } catch {
     if (warning) {
       console.warn(`[${warning.context}] Missing required package "${name}".`);

--- a/lib/pipes/validators/validation.pipe.ts
+++ b/lib/pipes/validators/validation.pipe.ts
@@ -18,7 +18,7 @@ export interface ValidationPipeOptions extends ValidatorOptions {
  */
 export function ValidationPipe(options?: ValidationPipeOptions): ParameterPipe<any> {
   if (process.env.NODE_ENV === 'development') {
-    ['class-validator', 'class-transformer'].forEach(requiredPackage =>
+    (['class-validator', 'class-transformer'] as const).forEach(requiredPackage =>
       loadPackage(requiredPackage, {
         context: 'ValidationPipe',
         docsUrl: 'https://github.com/storyofams/next-api-decorators#data-transfer-object'


### PR DESCRIPTION
Since Webpack wants to know which packages to load prior to build, we fix it by specifying specific `require`s per package.